### PR TITLE
Fix spaces in filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ Client.on('messageCreate', (message) => {
             var Results = JSON.parse(html);
             var Selection = Math.floor(Math.random() * Results.length) - 1;
             console.log(Results[Selection].path)
-            message.channel.send("https://raw.githubusercontent.com/cat-milk/Anime-Girls-Holding-Programming-Books/master/" + Results[Selection].path)
+            message.channel.send(Results[Selection].download_url)
         })
     }
 })


### PR DESCRIPTION
[Example](https://raw.githubusercontent.com/cat-milk/Anime-Girls-Holding-Programming-Books/master/AI/tsunade%20artificial.png)

Using download_url instead of manually crafting the link automatically URI encodes problematic characters.